### PR TITLE
Fix atomicfu not being resolved

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,5 @@ kotlin.native.enableParallelExecutionCheck=false
 # org.gradle.parallel=true
 
 group=dev.gumil.kaskade
-version=0.4.0
+version=0.4.1
 libraryName=Kaskade

--- a/kaskade/coroutines/coroutines.gradle.kts
+++ b/kaskade/coroutines/coroutines.gradle.kts
@@ -24,12 +24,6 @@ kotlin {
             }
         }
 
-        val nativeMain by creating {
-            dependencies {
-                implementation(deps.kotlin.coroutines.native)
-            }
-        }
-
         jvm().compilations["main"].defaultSourceSet {
             dependencies {
                 implementation(deps.kotlin.coroutines.core)
@@ -52,10 +46,14 @@ kotlin {
                 implementation(kotlin("test-js"))
             }
         }
-    }
 
-    configure(listOf(iosX64(), iosArm64())) {
-        compilations["main"].source(sourceSets["nativeMain"])
+        configure(listOf(iosX64(), iosArm64())) {
+            compilations["main"].defaultSourceSet {
+                dependencies {
+                    implementation(deps.kotlin.coroutines.native)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
There was this error when using Kaskade into a multiplatform project:
e: Could not find "atomicfu-cinterop-interop"

Apparently this was caused by a wrong configuration in source sets.
Test was passing but the library built didn't have the dependencies.